### PR TITLE
Extraneous dependencies for Assembly Mapping

### DIFF
--- a/AssemblyMapper/cpanfile
+++ b/AssemblyMapper/cpanfile
@@ -1,0 +1,2 @@
+requires 'MooseX::ClassAttribute';
+requires 'MooseX::Params::Validate';


### PR DESCRIPTION
Not held in ensembl-core cpanfile because we do not want all core API consumers to have to install Moose + friends